### PR TITLE
Fixed typo in promises task text

### DIFF
--- a/promises-async-await/README.md
+++ b/promises-async-await/README.md
@@ -40,7 +40,7 @@ export default function read() {
   return new Promise((resolve, reject) => {
     // эмуляция чтения файла
     setTimeout(() => {
-      const data = '{"id":9,"created":1546300800,"userInfo":{"id":1,name":"Hitman","level":10,"points":2000}}';
+      const data = '{"id":9,"created":1546300800,"userInfo":{"id":1,"name":"Hitman","level":10,"points":2000}}';
       return (input => {
         const buffer = new ArrayBuffer(input.length * 2);
         const bufferView = new Uint16Array(buffer);


### PR DESCRIPTION
Исправлена ошибка в тексте задания, пропала открывающая кавычка в имени поля `name`, что делало JSON не валидным